### PR TITLE
hotfix linting process

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,12 +14,12 @@ lint:
 	$(BIN)flake8 --jobs 4 --statistics --show-source $(CODE) tests
 	$(BIN)pylint --jobs 4 --rcfile=setup.cfg $(CODE)
 	$(BIN)mypy $(CODE) tests
-	$(BIN)black --py36 --skip-string-normalization --line-length=79 --check $(CODE) tests
+	$(BIN)black --target-version=py36 --skip-string-normalization --line-length=79 --check $(CODE) tests
 	$(BIN)pytest --dead-fixtures --dup-fixtures
 
 pretty:
 	$(BIN)isort --apply --recursive $(CODE) tests
-	$(BIN)black --py36 --skip-string-normalization --line-length=79 $(CODE) tests
+	$(BIN)black --target-version=py36 --skip-string-normalization --line-length=79 $(CODE) tests
 	$(BIN)unify --in-place --recursive $(CODE) tests
 
 precommit_install:


### PR DESCRIPTION
Right now there's a bug in you're linting CI because the latest version of black doesn't support the `--py36` flag.
I replace it with the current equivalent (see https://black.readthedocs.io/en/stable/change_log.html?highlight=--py36#id2)