### PR TITLE
Fix/47/Update-R504-for-assignment-value

### DIFF
--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -51,6 +51,9 @@ class UnnecessaryAssignMixin(Visitor):
         if not self._stack:
             return
 
+        if isinstance(node.value, ast.Name):
+            self.refs[node.value.id].append(node.value.lineno)
+
         self.generic_visit(node.value)
 
         target = node.targets[0]

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -21,7 +21,7 @@ RETURNS = 'returns'
 
 
 class UnnecessaryAssignMixin(Visitor):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._loop_count: int = 0
 

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -21,8 +21,8 @@ RETURNS = 'returns'
 
 
 class UnnecessaryAssignMixin(Visitor):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self._loop_count: int = 0
 
     @property
@@ -177,8 +177,8 @@ class ReturnVisitor(
     ImplicitReturnMixin,
     ImplicitReturnValueMixin,
 ):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self._stack: List[Any] = []
 
     @property

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -177,7 +177,7 @@ class ReturnVisitor(
     ImplicitReturnMixin,
     ImplicitReturnValueMixin,
 ):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._stack: List[Any] = []
 

--- a/tests/test_unnecessary_assign.py
+++ b/tests/test_unnecessary_assign.py
@@ -106,6 +106,26 @@ error_not_exists = (
             i = i - x
         return val
     """,
+
+    # Test cases for using value for assignment then returning it
+    # See:https://github.com/afonasev/flake8-return/issues/47
+    """
+    def resolve_from_url(self, url: str) -> dict:
+        local_match = self.local_scope_re.match(url)
+        if local_match:
+            schema = get_schema(name=local_match.group(1))
+            self.store[url] = schema
+            return schema
+        raise NotImplementedError(...)
+    """,
+    """
+    my_dict = {}
+
+    def my_func():
+        foo = calculate_foo()
+        my_dict["foo_result"] = foo
+        return foo
+    """,
 )
 
 

--- a/tests/test_unnecessary_assign.py
+++ b/tests/test_unnecessary_assign.py
@@ -40,6 +40,48 @@ unnecessary_assign = (
         print(a)
         return a
     """,
+
+    # Incorrect false positives - can be refactored
+
+    # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
+    """ 
+    def get_bar_if_exists(obj):
+        result = ""
+        if hasattr(obj, "bar"):
+            result = str(obj.bar)
+        return result
+    """,
+
+    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
+    """
+    def x():
+        formatted = _USER_AGENT_FORMATTER.format(format_string, **values)
+        # clean up after any blank components
+        formatted = formatted.replace('()', '').replace('  ', ' ').strip()
+        return formatted
+    """,
+
+    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
+    """
+    def user_agent_username(username=None):
+
+        if not username:
+            return ''
+
+        username = username.replace(' ', '_')  # Avoid spaces or %20.
+        try:
+            username.encode('ascii')  # just test, but not actually use it
+        except UnicodeEncodeError:
+            username = quote(username.encode('utf-8'))
+        else:
+            # % is legal in the default $wgLegalTitleChars
+            # This is so that ops know the real pywikibot will not
+            # allow a useragent in the username to allow through a hand-coded
+            # percent-encoded value.
+            if '%' in username:
+                username = quote(username)
+        return username 
+    """,
 )
 
 
@@ -125,6 +167,48 @@ error_not_exists = (
         foo = calculate_foo()
         my_dict["foo_result"] = foo
         return foo
+    """,
+
+    # Refactored incorrect false positives
+    # See test cases above marked: "Incorrect false positives - can be refactored"
+
+    # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
+    """ 
+    def get_bar_if_exists(obj):
+        if hasattr(obj, "bar"):
+            return str(obj.bar)
+        return ""
+    """,
+
+    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
+    """
+    def x():
+        formatted = _USER_AGENT_FORMATTER.format(format_string, **values)
+        # clean up after any blank components
+        return formatted.replace('()', '').replace('  ', ' ').strip()
+    """,
+
+    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
+    """
+    def user_agent_username(username=None):
+
+        if not username:
+            return ''
+
+        username = username.replace(' ', '_')  # Avoid spaces or %20.
+        try:
+            username.encode('ascii')  # just test, but not actually use it
+        except UnicodeEncodeError:
+            username = quote(username.encode('utf-8'))
+        else:
+            # % is legal in the default $wgLegalTitleChars
+            # This is so that ops know the real pywikibot will not
+            # allow a useragent in the username to allow through a hand-coded
+            # percent-encoded value.
+            if '%' in username:
+                return quote(username)
+        finally:
+            return username 
     """,
 )
 

--- a/tests/test_unnecessary_assign.py
+++ b/tests/test_unnecessary_assign.py
@@ -40,29 +40,25 @@ unnecessary_assign = (
         print(a)
         return a
     """,
-
     # Incorrect false positives - can be refactored
-
-    # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
     """
+    # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
     def get_bar_if_exists(obj):
         result = ""
         if hasattr(obj, "bar"):
             result = str(obj.bar)
         return result
     """,
-
-    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
     """
+    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
     def x():
         formatted = _USER_AGENT_FORMATTER.format(format_string, **values)
         # clean up after any blank components
         formatted = formatted.replace('()', '').replace('  ', ' ').strip()
         return formatted
     """,
-
-    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
     """
+    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
     def user_agent_username(username=None):
 
         if not username:
@@ -148,10 +144,9 @@ error_not_exists = (
             i = i - x
         return val
     """,
-
     # Test cases for using value for assignment then returning it
-    # See:https://github.com/afonasev/flake8-return/issues/47
     """
+    # See:https://github.com/afonasev/flake8-return/issues/47
     def resolve_from_url(self, url: str) -> dict:
         local_match = self.local_scope_re.match(url)
         if local_match:
@@ -168,28 +163,24 @@ error_not_exists = (
         my_dict["foo_result"] = foo
         return foo
     """,
-
     # Refactored incorrect false positives
     # See test cases above marked: "Incorrect false positives - can be refactored"
-
-    # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
     """
+    # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
     def get_bar_if_exists(obj):
         if hasattr(obj, "bar"):
             return str(obj.bar)
         return ""
     """,
-
-    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
     """
+    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
     def x():
         formatted = _USER_AGENT_FORMATTER.format(format_string, **values)
         # clean up after any blank components
         return formatted.replace('()', '').replace('  ', ' ').strip()
     """,
-
-    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
     """
+    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
     def user_agent_username(username=None):
 
         if not username:

--- a/tests/test_unnecessary_assign.py
+++ b/tests/test_unnecessary_assign.py
@@ -44,7 +44,7 @@ unnecessary_assign = (
     # Incorrect false positives - can be refactored
 
     # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
-    """ 
+    """
     def get_bar_if_exists(obj):
         result = ""
         if hasattr(obj, "bar"):
@@ -80,7 +80,7 @@ unnecessary_assign = (
             # percent-encoded value.
             if '%' in username:
                 username = quote(username)
-        return username 
+        return username
     """,
 )
 
@@ -173,7 +173,7 @@ error_not_exists = (
     # See test cases above marked: "Incorrect false positives - can be refactored"
 
     # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
-    """ 
+    """
     def get_bar_if_exists(obj):
         if hasattr(obj, "bar"):
             return str(obj.bar)
@@ -208,7 +208,7 @@ error_not_exists = (
             if '%' in username:
                 return quote(username)
         finally:
-            return username 
+            return username
     """,
 )
 


### PR DESCRIPTION
This PR updates the `visit_Assign` function to get `refs` for the assignment value. This fixes a couple of the issues that can be found in #47, b0109af5fe27986d5372a54a2cfd43d1fff97efd. All other issues can be refactored to get R504 to pass (see 47c5b3c64c832acc9ba679fe50ab1b12b5df821b). 

As @ericbn, [notes](https://github.com/afonasev/flake8-return/issues/47#issuecomment-1077714924), this rule could be considered controversial, so it could potentially be updated to be optional in another issue/pr.  

Fixes #47.