### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -20,6 +20,6 @@ jobs:
           pip install setuptools --editable . || true
           mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
-      - run: pytest . || true
+      - run: pytest .
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -14,7 +14,7 @@ jobs:
       - run: bandit --recursive .
       - run: black --check --line-length=79 --skip-string-normalization .
       - run: codespell
-      - run: flake8 . --count --max-complexity=10 --max-line-length=88 --show-source --statistics
+      - run: flake8 . --count --statistics
       - run: isort --check-only .
       - run: |
           pip install setuptools --editable . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,7 +12,7 @@ jobs:
       - run: pip install bandit black codespell flake8 flake8-bugbear
                          flake8-comprehensions isort mypy pytest pyupgrade safety
       - run: bandit --recursive .
-      - run: black --check . || true
+      - run: black --check --line-length=79 --skip-string-normalization .
       - run: codespell
       - run: flake8 . --count --max-complexity=10 --max-line-length=88 --show-source --statistics
       - run: isort --check-only .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,12 @@
 [flake8]
 enable-extensions = G
-exclude = .git, .venv
+exclude = .git, .venv, env
 ignore =
 	A003 ; 'id' is a python builtin, consider renaming the class attribute
 	W503 ; line break before binary operator
 	N802 ; function name 'visit_FunctionDef' should be lowercase
 max-complexity = 10
-max-line-length = 100
+max-line-length = 79
 show-source = true
 
 [mypy]

--- a/tests/test_unnecessary_assign.py
+++ b/tests/test_unnecessary_assign.py
@@ -40,7 +40,7 @@ unnecessary_assign = (
         print(a)
         return a
     """,
-    # Incorrect false positives - can be refactored
+    # Can be refactored false positives
     """
     # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
     def get_bar_if_exists(obj):
@@ -164,7 +164,7 @@ error_not_exists = (
         return foo
     """,
     # Refactored incorrect false positives
-    # See test cases above marked: "Incorrect false positives - can be refactored"
+    # See test cases above marked: "Can be refactored false positives"
     """
     # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
     def get_bar_if_exists(obj):


### PR DESCRIPTION
Previously even if some workflow steps were failing (e.g. black and pytest), the workflow would not fail. This is not ideal as errors might not be found, and duplicate workflow runs are required to identify issues (currently Github actions and Travis). 

This PR:
- Updates black and pytest steps to fail the workflow if the step fails
- Updates black step to match the configuration in the make file
- Updates flake8 to match black config

I don't have much experience with Travis CI, so reverted the attempts to update the minimum python version and black version as I could not get it to pass.