### PR TITLE
Port no-else-break, no-else-continue, no-else-raise, no-else-return from pylint

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.3
+current_version = 1.2.0
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,48 @@ def x():
     return a  # error!
 ```
 
+* R505 unnecessary else after return statement.
+
+```python
+def x(y, z):
+    if y:  # error!
+        return 1
+    else:
+        return z
+```
+
+* R506 unnecessary else after raise statement.
+
+```python
+def x(y, z):
+    if y:  # error!
+        raise Exception(y)
+    else:
+        raise Exception(z)
+```
+
+* R507 unnecessary else after continue statement.
+
+```python
+def x(y, z):
+    for i in y:
+        if i < z:  # error!
+            continue
+        else:
+            a = 0
+```
+
+* R508 unnecessary else after break statement.
+
+```python
+def x(y, z):
+    for i in y:
+        if i > z:  # error!
+            break
+        else:
+            a = 0
+```
+
 Returns in asyncio coroutines also supported.
 
 ## For developers

--- a/flake8_return/errors.py
+++ b/flake8_return/errors.py
@@ -28,3 +28,43 @@ class ImplicitReturn(Error):
 class UnnecessaryAssign(Error):
     code = 'R504'
     message = 'unnecessary variable assignment before return statement.'
+
+
+class SuperfluousElseReturn(Error):
+    code = 'R505'
+    message = 'unnecessary else after return statement.'
+
+
+class SuperfluousElifReturn(Error):
+    code = 'R506'
+    message = 'unnecessary elif after return statement.'
+
+
+class SuperfluousElseRaise(Error):
+    code = 'R507'
+    message = 'unnecessary else after raise statement.'
+
+
+class SuperfluousElifRaise(Error):
+    code = 'R508'
+    message = 'unnecessary elif after raise statement.'
+
+
+class SuperfluousElseContinue(Error):
+    code = 'R509'
+    message = 'unnecessary else after continue statement.'
+
+
+class SuperfluousElifContinue(Error):
+    code = 'R510'
+    message = 'unnecessary elif after continue statement.'
+
+
+class SuperfluousElseBreak(Error):
+    code = 'R511'
+    message = 'unnecessary else after break statement.'
+
+
+class SuperfluousElifBreak(Error):
+    code = 'R512'
+    message = 'unnecessary elif after break statement.'

--- a/flake8_return/errors.py
+++ b/flake8_return/errors.py
@@ -36,15 +36,15 @@ class SuperfluousElseReturn(Error):
 
 
 class SuperfluousElseRaise(Error):
-    code = 'R507'
+    code = 'R506'
     message = 'unnecessary else after raise statement.'
 
 
 class SuperfluousElseContinue(Error):
-    code = 'R509'
+    code = 'R507'
     message = 'unnecessary else after continue statement.'
 
 
 class SuperfluousElseBreak(Error):
-    code = 'R511'
+    code = 'R508'
     message = 'unnecessary else after break statement.'

--- a/flake8_return/errors.py
+++ b/flake8_return/errors.py
@@ -35,19 +35,9 @@ class SuperfluousElseReturn(Error):
     message = 'unnecessary else after return statement.'
 
 
-class SuperfluousElifReturn(Error):
-    code = 'R506'
-    message = 'unnecessary elif after return statement.'
-
-
 class SuperfluousElseRaise(Error):
     code = 'R507'
     message = 'unnecessary else after raise statement.'
-
-
-class SuperfluousElifRaise(Error):
-    code = 'R508'
-    message = 'unnecessary elif after raise statement.'
 
 
 class SuperfluousElseContinue(Error):
@@ -55,16 +45,6 @@ class SuperfluousElseContinue(Error):
     message = 'unnecessary else after continue statement.'
 
 
-class SuperfluousElifContinue(Error):
-    code = 'R510'
-    message = 'unnecessary elif after continue statement.'
-
-
 class SuperfluousElseBreak(Error):
     code = 'R511'
     message = 'unnecessary else after break statement.'
-
-
-class SuperfluousElifBreak(Error):
-    code = 'R512'
-    message = 'unnecessary elif after break statement.'

--- a/flake8_return/mixins/implicit_return.py
+++ b/flake8_return/mixins/implicit_return.py
@@ -1,0 +1,34 @@
+import ast
+
+from flake8_plugin_utils import Visitor
+
+from ..errors import ImplicitReturn
+from ..utils import is_false
+
+
+class ImplicitReturnMixin(Visitor):
+    def _check_implicit_return(self, last_node: ast.AST) -> None:
+        if isinstance(last_node, ast.If):
+            if not last_node.body or not last_node.orelse:
+                self.error_from_node(ImplicitReturn, last_node)
+                return
+
+            self._check_implicit_return(last_node.body[-1])
+            self._check_implicit_return(last_node.orelse[-1])
+            return
+
+        if isinstance(last_node, (ast.For, ast.AsyncFor)) and last_node.orelse:
+            self._check_implicit_return(last_node.orelse[-1])
+            return
+
+        if isinstance(last_node, (ast.With, ast.AsyncWith, ast.For)):
+            self._check_implicit_return(last_node.body[-1])
+            return
+
+        if isinstance(last_node, ast.Assert) and is_false(last_node.test):
+            return
+
+        if not isinstance(
+            last_node, (ast.Return, ast.Raise, ast.While, ast.Try)
+        ):
+            self.error_from_node(ImplicitReturn, last_node)

--- a/flake8_return/mixins/implicit_return_value.py
+++ b/flake8_return/mixins/implicit_return_value.py
@@ -1,0 +1,10 @@
+from flake8_plugin_utils import Visitor
+
+from ..errors import ImplicitReturnValue
+
+
+class ImplicitReturnValueMixin(Visitor):
+    def _check_implicit_return_value(self) -> None:
+        for node in self.returns:
+            if not node.value:
+                self.error_from_node(ImplicitReturnValue, node)

--- a/flake8_return/mixins/superfluous_return.py
+++ b/flake8_return/mixins/superfluous_return.py
@@ -1,0 +1,72 @@
+import ast
+from typing import List
+
+from flake8_plugin_utils import Visitor
+
+from ..errors import (
+    SuperfluousElseBreak,
+    SuperfluousElseContinue,
+    SuperfluousElseRaise,
+    SuperfluousElseReturn,
+)
+from ..stack_keys import ELIFS, IFS
+
+
+class SuperfluousReturnMixin(Visitor):
+    superfluous_list = [
+        (ast.Return, SuperfluousElseReturn),
+        (ast.Break, SuperfluousElseBreak),
+        (ast.Raise, SuperfluousElseRaise),
+        (ast.Continue, SuperfluousElseContinue),
+    ]
+
+    @property
+    def ifs(self) -> List[ast.If]:
+        if len(self._stack) > 0:
+            return self._stack[-1][IFS]
+        return []
+
+    @property
+    def elifs(self) -> List[ast.If]:
+        return self._stack[-1][ELIFS]
+
+    def visit_If(self, node: ast.If) -> None:
+        if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
+            self.elifs.append(node)
+        else:
+            self.ifs.append(node)
+
+        self.generic_visit(node)
+
+    def _updated_error_message(self, message: str, check: str) -> str:
+        message = message.replace("else", "[check]")
+        message = message.replace("elif", "[check]")
+        return message.replace("[check]", check)
+
+    def _check_superfluous_else_node(self, node: ast.If, check: str) -> bool:
+        for statement, error in self.superfluous_list:
+            if any(isinstance(node, statement) for node in node.body):
+                message = getattr(error, "message", "")
+                message = self._updated_error_message(message, check)
+                setattr(error, "message", message)  # noqa: B010
+                self.error_from_node(error, node)
+                return True
+
+        return False
+
+    def _check_superfluous_else(self) -> bool:
+        for node in self.ifs:
+            if not node.orelse:
+                continue
+
+            if self._check_superfluous_else_node(node, "else"):
+                return True
+
+        return False
+
+    def _check_superfluous_elif(self) -> bool:
+        for node in self.elifs:
+            if self._check_superfluous_else_node(node, "elif"):
+                return True
+
+        return False

--- a/flake8_return/mixins/superfluous_return.py
+++ b/flake8_return/mixins/superfluous_return.py
@@ -28,7 +28,9 @@ class SuperfluousReturnMixin(Visitor):
 
     @property
     def elifs(self) -> List[ast.If]:
-        return self._stack[-1][ELIFS]
+        if len(self._stack) >0:
+            return self._stack[-1][ELIFS]
+        return []
 
     def visit_If(self, node: ast.If) -> None:
         if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):

--- a/flake8_return/mixins/superfluous_return.py
+++ b/flake8_return/mixins/superfluous_return.py
@@ -28,7 +28,7 @@ class SuperfluousReturnMixin(Visitor):
 
     @property
     def elifs(self) -> List[ast.If]:
-        if len(self._stack) >0:
+        if len(self._stack) > 0:
             return self._stack[-1][ELIFS]
         return []
 

--- a/flake8_return/mixins/unnecessary_assign.py
+++ b/flake8_return/mixins/unnecessary_assign.py
@@ -1,0 +1,158 @@
+import ast
+import sys
+from typing import Any, Dict, List, Optional, Union
+
+from flake8_plugin_utils import Visitor
+
+from ..errors import UnnecessaryAssign
+
+NameToLines = Dict[str, List[int]]
+BlockPosition = Dict[int, int]
+Loop = Union[ast.For, ast.AsyncFor, ast.While]
+
+
+class UnnecessaryAssignMixin(Visitor):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._loop_count: int = 0
+
+    @property
+    def assigns(self) -> NameToLines:
+        return self._stack[-1]['assigns']
+
+    @property
+    def refs(self) -> NameToLines:
+        return self._stack[-1]['refs']
+
+    @property
+    def tries(self) -> BlockPosition:
+        return self._stack[-1]['tries']
+
+    @property
+    def loops(self) -> BlockPosition:
+        return self._stack[-1]['loops']
+
+    def visit_For(self, node: ast.For) -> None:
+        self._visit_loop(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._visit_loop(node)
+
+    def visit_While(self, node: ast.While) -> None:
+        self._visit_loop(node)
+
+    def _visit_loop(self, node: Loop) -> None:
+        if sys.version_info >= (3, 8):
+            if self._stack:
+                if hasattr(node, "end_lineno") and node.end_lineno is not None:
+                    self.loops[node.lineno] = node.end_lineno
+            self.generic_visit(node)
+        else:
+            self._loop_count += 1
+            self.generic_visit(node)
+            self._loop_count -= 1
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if not self._stack:
+            return
+
+        if isinstance(node.value, ast.Name):
+            self.refs[node.value.id].append(node.value.lineno)
+
+        self.generic_visit(node.value)
+
+        target = node.targets[0]
+        if isinstance(target, ast.Tuple) and not isinstance(
+            node.value, ast.Tuple
+        ):
+            # skip unpacking assign e.g: x, y = my_object
+            return
+
+        self._visit_assign_target(target)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if self._stack:
+            self.refs[node.id].append(node.lineno)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        if sys.version_info >= (3, 8):
+            if self._stack:
+                if hasattr(node, "end_lineno") and node.end_lineno is not None:
+                    self.tries[node.lineno] = node.end_lineno
+        self.generic_visit(node)
+
+    def _visit_assign_target(self, node: ast.AST) -> None:
+        if isinstance(node, ast.Tuple):
+            for n in node.elts:
+                self._visit_assign_target(n)
+            return
+
+        if sys.version_info >= (3, 8) or not self._loop_count:
+            if isinstance(node, ast.Name):
+                self.assigns[node.id].append(node.lineno)
+                return
+
+        # get item, etc.
+        self.generic_visit(node)
+
+    def _check_unnecessary_assign(self, node: ast.AST) -> None:
+        if not isinstance(node, ast.Name):
+            return
+
+        var_name = node.id
+        return_lineno = node.lineno
+
+        if var_name not in self.assigns:
+            return
+
+        if var_name not in self.refs:
+            self.error_from_node(UnnecessaryAssign, node)
+            return
+
+        if self._has_refs_before_next_assign(var_name, return_lineno):
+            return
+
+        if sys.version_info >= (3, 8):
+            if self._has_refs_or_assigns_within_try_or_loop(var_name):
+                return
+
+        self.error_from_node(UnnecessaryAssign, node)
+
+    def _has_refs_or_assigns_within_try_or_loop(self, var_name: str) -> bool:
+        for item in [*self.refs[var_name], *self.assigns[var_name]]:
+            for try_start, try_end in self.tries.items():
+                if try_start < item <= try_end:
+                    return True
+
+            for loop_start, loop_end in self.loops.items():
+                if loop_start < item <= loop_end:
+                    return True
+
+        return False
+
+    def _has_refs_before_next_assign(
+        self, var_name: str, return_lineno: int
+    ) -> bool:
+        before_assign = 0
+        after_assign: Optional[int] = None
+
+        for lineno in sorted(self.assigns[var_name]):
+            if lineno > return_lineno:
+                after_assign = lineno
+                break
+
+            if lineno <= return_lineno:
+                before_assign = lineno
+
+        for lineno in self.refs[var_name]:
+            if lineno == return_lineno:
+                continue
+
+            if after_assign:
+                if before_assign < lineno <= after_assign:
+                    return True
+
+            elif before_assign < lineno:
+                return True
+
+        return False

--- a/flake8_return/mixins/unnecessary_return_none.py
+++ b/flake8_return/mixins/unnecessary_return_none.py
@@ -1,0 +1,11 @@
+from flake8_plugin_utils import Visitor
+
+from ..errors import UnnecessaryReturnNone
+from ..utils import is_none
+
+
+class UnnecessaryReturnNoneMixin(Visitor):
+    def _check_unnecessary_return_none(self) -> None:
+        for node in self.returns:
+            if is_none(node.value):
+                self.error_from_node(UnnecessaryReturnNone, node)

--- a/flake8_return/plugin.py
+++ b/flake8_return/plugin.py
@@ -2,7 +2,7 @@ from flake8_plugin_utils import Plugin
 
 from .visitors import ReturnVisitor
 
-__version__ = '1.1.3'
+__version__ = '1.2.0'
 
 
 class ReturnPlugin(Plugin):

--- a/flake8_return/stack_keys.py
+++ b/flake8_return/stack_keys.py
@@ -1,0 +1,19 @@
+import ast
+from typing import Optional
+
+
+def is_none(node: Optional[ast.AST]) -> bool:
+    return isinstance(node, ast.NameConstant) and node.value is None
+
+
+def is_false(node: Optional[ast.AST]) -> bool:
+    return isinstance(node, ast.NameConstant) and node.value is False
+
+
+ASSIGNS = 'assigns'
+REFS = 'refs'
+RETURNS = 'returns'
+TRIES = 'tries'
+LOOPS = 'loops'
+IFS = 'ifs'
+ELIFS = 'elifs'

--- a/flake8_return/stack_keys.py
+++ b/flake8_return/stack_keys.py
@@ -1,15 +1,3 @@
-import ast
-from typing import Optional
-
-
-def is_none(node: Optional[ast.AST]) -> bool:
-    return isinstance(node, ast.NameConstant) and node.value is None
-
-
-def is_false(node: Optional[ast.AST]) -> bool:
-    return isinstance(node, ast.NameConstant) and node.value is False
-
-
 ASSIGNS = 'assigns'
 REFS = 'refs'
 RETURNS = 'returns'

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -246,7 +246,7 @@ class SuperfluousReturnMixin(Visitor):
 
         self.generic_visit(node)
 
-    def _updated_error_message(self, message, check) -> str:
+    def _updated_error_message(self, message: str, check: str) -> str:
         message = message.replace("else", "[check]")
         message = message.replace("elif", "[check]")
         return message.replace("[check]", check)
@@ -254,9 +254,9 @@ class SuperfluousReturnMixin(Visitor):
     def _check_superfluous_else_node(self, node: ast.If, check: str) -> bool:
         for statement, error in self.superfluous_list:
             if any(isinstance(node, statement) for node in node.body):
-                error.message = self._updated_error_message(
-                    error.message, check
-                )
+                message = getattr(error, "message", "")
+                message = self._updated_error_message(message, check)
+                setattr(error, "message", message)
                 self.error_from_node(error, node)
                 return True
 

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -201,7 +201,7 @@ class ImplicitReturnMixin(Visitor):
             self._check_implicit_return(last_node.orelse[-1])
             return
 
-        if isinstance(last_node, (ast.With, ast.AsyncWith)):
+        if isinstance(last_node, (ast.With, ast.AsyncWith, ast.For)):
             self._check_implicit_return(last_node.body[-1])
             return
 

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -1,7 +1,6 @@
 import ast
-import sys
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 from flake8_plugin_utils import Visitor
 
@@ -12,9 +11,9 @@ from .errors import (
     SuperfluousElseContinue,
     SuperfluousElseRaise,
     SuperfluousElseReturn,
-    UnnecessaryAssign,
     UnnecessaryReturnNone,
 )
+from .mixins.unnecessary_assign import UnnecessaryAssignMixin
 from .stack_keys import ASSIGNS, ELIFS, IFS, LOOPS, REFS, RETURNS, TRIES
 from .utils import is_false, is_none
 
@@ -22,153 +21,6 @@ NameToLines = Dict[str, List[int]]
 BlockPosition = Dict[int, int]
 Function = Union[ast.AsyncFunctionDef, ast.FunctionDef]
 Loop = Union[ast.For, ast.AsyncFor, ast.While]
-
-
-class UnnecessaryAssignMixin(Visitor):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._loop_count: int = 0
-
-    @property
-    def assigns(self) -> NameToLines:
-        return self._stack[-1][ASSIGNS]
-
-    @property
-    def refs(self) -> NameToLines:
-        return self._stack[-1][REFS]
-
-    @property
-    def tries(self) -> BlockPosition:
-        return self._stack[-1][TRIES]
-
-    @property
-    def loops(self) -> BlockPosition:
-        return self._stack[-1][LOOPS]
-
-    def visit_For(self, node: ast.For) -> None:
-        self._visit_loop(node)
-
-    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
-        self._visit_loop(node)
-
-    def visit_While(self, node: ast.While) -> None:
-        self._visit_loop(node)
-
-    def _visit_loop(self, node: Loop) -> None:
-        if sys.version_info >= (3, 8):
-            if self._stack:
-                if hasattr(node, "end_lineno") and node.end_lineno is not None:
-                    self.loops[node.lineno] = node.end_lineno
-            self.generic_visit(node)
-        else:
-            self._loop_count += 1
-            self.generic_visit(node)
-            self._loop_count -= 1
-
-    def visit_Assign(self, node: ast.Assign) -> None:
-        if not self._stack:
-            return
-
-        if isinstance(node.value, ast.Name):
-            self.refs[node.value.id].append(node.value.lineno)
-
-        self.generic_visit(node.value)
-
-        target = node.targets[0]
-        if isinstance(target, ast.Tuple) and not isinstance(
-            node.value, ast.Tuple
-        ):
-            # skip unpacking assign e.g: x, y = my_object
-            return
-
-        self._visit_assign_target(target)
-
-    def visit_Name(self, node: ast.Name) -> None:
-        if self._stack:
-            self.refs[node.id].append(node.lineno)
-
-    def visit_Try(self, node: ast.Try) -> None:
-        if sys.version_info >= (3, 8):
-            if self._stack:
-                if hasattr(node, "end_lineno") and node.end_lineno is not None:
-                    self.tries[node.lineno] = node.end_lineno
-        self.generic_visit(node)
-
-    def _visit_assign_target(self, node: ast.AST) -> None:
-        if isinstance(node, ast.Tuple):
-            for n in node.elts:
-                self._visit_assign_target(n)
-            return
-
-        if sys.version_info >= (3, 8) or not self._loop_count:
-            if isinstance(node, ast.Name):
-                self.assigns[node.id].append(node.lineno)
-                return
-
-        # get item, etc.
-        self.generic_visit(node)
-
-    def _check_unnecessary_assign(self, node: ast.AST) -> None:
-        if not isinstance(node, ast.Name):
-            return
-
-        var_name = node.id
-        return_lineno = node.lineno
-
-        if var_name not in self.assigns:
-            return
-
-        if var_name not in self.refs:
-            self.error_from_node(UnnecessaryAssign, node)
-            return
-
-        if self._has_refs_before_next_assign(var_name, return_lineno):
-            return
-
-        if sys.version_info >= (3, 8):
-            if self._has_refs_or_assigns_within_try_or_loop(var_name):
-                return
-
-        self.error_from_node(UnnecessaryAssign, node)
-
-    def _has_refs_or_assigns_within_try_or_loop(self, var_name: str) -> bool:
-        for item in [*self.refs[var_name], *self.assigns[var_name]]:
-            for try_start, try_end in self.tries.items():
-                if try_start < item <= try_end:
-                    return True
-
-            for loop_start, loop_end in self.loops.items():
-                if loop_start < item <= loop_end:
-                    return True
-
-        return False
-
-    def _has_refs_before_next_assign(
-        self, var_name: str, return_lineno: int
-    ) -> bool:
-        before_assign = 0
-        after_assign: Optional[int] = None
-
-        for lineno in sorted(self.assigns[var_name]):
-            if lineno > return_lineno:
-                after_assign = lineno
-                break
-
-            if lineno <= return_lineno:
-                before_assign = lineno
-
-        for lineno in self.refs[var_name]:
-            if lineno == return_lineno:
-                continue
-
-            if after_assign:
-                if before_assign < lineno <= after_assign:
-                    return True
-
-            elif before_assign < lineno:
-                return True
-
-        return False
 
 
 class UnnecessaryReturnNoneMixin(Visitor):

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -2,82 +2,15 @@ import ast
 from collections import defaultdict
 from typing import Any, List, Union
 
-from flake8_plugin_utils import Visitor
-
-from .errors import (
-    SuperfluousElseBreak,
-    SuperfluousElseContinue,
-    SuperfluousElseRaise,
-    SuperfluousElseReturn,
-)
 from .mixins.implicit_return import ImplicitReturnMixin
 from .mixins.implicit_return_value import ImplicitReturnValueMixin
+from .mixins.superfluous_return import SuperfluousReturnMixin
 from .mixins.unnecessary_assign import UnnecessaryAssignMixin
 from .mixins.unnecessary_return_none import UnnecessaryReturnNoneMixin
 from .stack_keys import ASSIGNS, ELIFS, IFS, LOOPS, REFS, RETURNS, TRIES
 from .utils import is_none
 
 Function = Union[ast.AsyncFunctionDef, ast.FunctionDef]
-
-
-class SuperfluousReturnMixin(Visitor):
-    superfluous_list = [
-        (ast.Return, SuperfluousElseReturn),
-        (ast.Break, SuperfluousElseBreak),
-        (ast.Raise, SuperfluousElseRaise),
-        (ast.Continue, SuperfluousElseContinue),
-    ]
-
-    @property
-    def ifs(self) -> List[ast.If]:
-        if len(self._stack) > 0:
-            return self._stack[-1][IFS]
-        return []
-
-    @property
-    def elifs(self) -> List[ast.If]:
-        return self._stack[-1][ELIFS]
-
-    def visit_If(self, node: ast.If) -> None:
-        if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
-            self.elifs.append(node)
-        else:
-            self.ifs.append(node)
-
-        self.generic_visit(node)
-
-    def _updated_error_message(self, message: str, check: str) -> str:
-        message = message.replace("else", "[check]")
-        message = message.replace("elif", "[check]")
-        return message.replace("[check]", check)
-
-    def _check_superfluous_else_node(self, node: ast.If, check: str) -> bool:
-        for statement, error in self.superfluous_list:
-            if any(isinstance(node, statement) for node in node.body):
-                message = getattr(error, "message", "")
-                message = self._updated_error_message(message, check)
-                setattr(error, "message", message)  # noqa: B010
-                self.error_from_node(error, node)
-                return True
-
-        return False
-
-    def _check_superfluous_else(self) -> bool:
-        for node in self.ifs:
-            if not node.orelse:
-                continue
-
-            if self._check_superfluous_else_node(node, "else"):
-                return True
-
-        return False
-
-    def _check_superfluous_elif(self) -> bool:
-        for node in self.elifs:
-            if self._check_superfluous_else_node(node, "elif"):
-                return True
-
-        return False
 
 
 class ReturnVisitor(

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -256,7 +256,7 @@ class SuperfluousReturnMixin(Visitor):
             if any(isinstance(node, statement) for node in node.body):
                 message = getattr(error, "message", "")
                 message = self._updated_error_message(message, check)
-                setattr(error, "message", message)
+                setattr(error, "message", message)  # noqa: B010
                 self.error_from_node(error, node)
                 return True
 

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -15,20 +15,13 @@ from .errors import (
     UnnecessaryAssign,
     UnnecessaryReturnNone,
 )
+from .stack_keys import ASSIGNS, ELIFS, IFS, LOOPS, REFS, RETURNS, TRIES
 from .utils import is_false, is_none
 
 NameToLines = Dict[str, List[int]]
 BlockPosition = Dict[int, int]
 Function = Union[ast.AsyncFunctionDef, ast.FunctionDef]
 Loop = Union[ast.For, ast.AsyncFor, ast.While]
-
-ASSIGNS = 'assigns'
-REFS = 'refs'
-RETURNS = 'returns'
-TRIES = 'tries'
-LOOPS = 'loops'
-IFS = 'ifs'
-ELIFS = 'elifs'
 
 
 class UnnecessaryAssignMixin(Visitor):

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -5,47 +5,19 @@ from typing import Any, List, Union
 from flake8_plugin_utils import Visitor
 
 from .errors import (
-    ImplicitReturn,
     SuperfluousElseBreak,
     SuperfluousElseContinue,
     SuperfluousElseRaise,
     SuperfluousElseReturn,
 )
+from .mixins.implicit_return import ImplicitReturnMixin
 from .mixins.implicit_return_value import ImplicitReturnValueMixin
 from .mixins.unnecessary_assign import UnnecessaryAssignMixin
 from .mixins.unnecessary_return_none import UnnecessaryReturnNoneMixin
 from .stack_keys import ASSIGNS, ELIFS, IFS, LOOPS, REFS, RETURNS, TRIES
-from .utils import is_false, is_none
+from .utils import is_none
 
 Function = Union[ast.AsyncFunctionDef, ast.FunctionDef]
-
-
-class ImplicitReturnMixin(Visitor):
-    def _check_implicit_return(self, last_node: ast.AST) -> None:
-        if isinstance(last_node, ast.If):
-            if not last_node.body or not last_node.orelse:
-                self.error_from_node(ImplicitReturn, last_node)
-                return
-
-            self._check_implicit_return(last_node.body[-1])
-            self._check_implicit_return(last_node.orelse[-1])
-            return
-
-        if isinstance(last_node, (ast.For, ast.AsyncFor)) and last_node.orelse:
-            self._check_implicit_return(last_node.orelse[-1])
-            return
-
-        if isinstance(last_node, (ast.With, ast.AsyncWith, ast.For)):
-            self._check_implicit_return(last_node.body[-1])
-            return
-
-        if isinstance(last_node, ast.Assert) and is_false(last_node.test):
-            return
-
-        if not isinstance(
-            last_node, (ast.Return, ast.Raise, ast.While, ast.Try)
-        ):
-            self.error_from_node(ImplicitReturn, last_node)
 
 
 class SuperfluousReturnMixin(Visitor):

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -11,9 +11,9 @@ from .errors import (
     SuperfluousElseContinue,
     SuperfluousElseRaise,
     SuperfluousElseReturn,
-    UnnecessaryReturnNone,
 )
 from .mixins.unnecessary_assign import UnnecessaryAssignMixin
+from .mixins.unnecessary_return_none import UnnecessaryReturnNoneMixin
 from .stack_keys import ASSIGNS, ELIFS, IFS, LOOPS, REFS, RETURNS, TRIES
 from .utils import is_false, is_none
 
@@ -21,13 +21,6 @@ NameToLines = Dict[str, List[int]]
 BlockPosition = Dict[int, int]
 Function = Union[ast.AsyncFunctionDef, ast.FunctionDef]
 Loop = Union[ast.For, ast.AsyncFor, ast.While]
-
-
-class UnnecessaryReturnNoneMixin(Visitor):
-    def _check_unnecessary_return_none(self) -> None:
-        for node in self.returns:
-            if is_none(node.value):
-                self.error_from_node(UnnecessaryReturnNone, node)
 
 
 class ImplicitReturnValueMixin(Visitor):

--- a/flake8_return/visitors.py
+++ b/flake8_return/visitors.py
@@ -1,33 +1,23 @@
 import ast
 from collections import defaultdict
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 from flake8_plugin_utils import Visitor
 
 from .errors import (
     ImplicitReturn,
-    ImplicitReturnValue,
     SuperfluousElseBreak,
     SuperfluousElseContinue,
     SuperfluousElseRaise,
     SuperfluousElseReturn,
 )
+from .mixins.implicit_return_value import ImplicitReturnValueMixin
 from .mixins.unnecessary_assign import UnnecessaryAssignMixin
 from .mixins.unnecessary_return_none import UnnecessaryReturnNoneMixin
 from .stack_keys import ASSIGNS, ELIFS, IFS, LOOPS, REFS, RETURNS, TRIES
 from .utils import is_false, is_none
 
-NameToLines = Dict[str, List[int]]
-BlockPosition = Dict[int, int]
 Function = Union[ast.AsyncFunctionDef, ast.FunctionDef]
-Loop = Union[ast.For, ast.AsyncFor, ast.While]
-
-
-class ImplicitReturnValueMixin(Visitor):
-    def _check_implicit_return_value(self) -> None:
-        for node in self.returns:
-            if not node.value:
-                self.error_from_node(ImplicitReturnValue, node)
 
 
 class ImplicitReturnMixin(Visitor):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flake8-return"
-version = "1.1.3"
+version = "1.2.0"
 description = "Flake8 plugin that checks return values"
 authors = ["Afonasev Evgeniy <ea.afonasev@gmail.com>"]
 license = "MIT"

--- a/tests/test_implicit_return.py
+++ b/tests/test_implicit_return.py
@@ -100,6 +100,41 @@ error_not_exists = (
             return 1
         assert False, 'Sanity check'
     """,
+    # return value within loop
+    """
+    def bar1(x, y, z):
+        for i in x:
+            if i > y:
+                break
+            return z
+    """,
+    """
+    def bar3(x, y, z):
+        for i in x:
+            if i > y:
+                if z:
+                    break
+            else:
+                return z
+            return None
+    """,
+        """
+    def bar1(x, y, z):
+        for i in x:
+            if i < y:
+                continue
+            return z
+    """,
+    """
+    def bar3(x, y, z):
+        for i in x:
+            if i < y:
+                if z:
+                    continue
+            else:
+                return z
+            return None
+    """,
 )
 
 

--- a/tests/test_implicit_return.py
+++ b/tests/test_implicit_return.py
@@ -25,15 +25,6 @@ implicit_return = (
     def x(y):
         if not y:
             return 1
-        elif y - 100:
-            print()  # error
-        else:
-            return 2
-    """,
-    """
-    def x(y):
-        if not y:
-            return 1
 
         print()  # error
     """,

--- a/tests/test_implicit_return.py
+++ b/tests/test_implicit_return.py
@@ -118,7 +118,7 @@ error_not_exists = (
                 return z
             return None
     """,
-        """
+    """
     def bar1(x, y, z):
         for i in x:
             if i < y:

--- a/tests/test_implicit_return.py
+++ b/tests/test_implicit_return.py
@@ -34,8 +34,8 @@ implicit_return = (
     def x(y):
         if not y:
             return 1
-        else:
-            print()  # error
+
+        print()  # error
     """,
     # for
     """

--- a/tests/test_implicit_return_value.py
+++ b/tests/test_implicit_return_value.py
@@ -46,15 +46,6 @@ error_not_exists = (
     """,
     """
     def x(y):
-        if not y:
-            return 1
-        elif y - 10:
-            return 2
-        else:
-            return 3
-    """,
-    """
-    def x(y):
         for i in range(10):
             if i > 100:
                 return i

--- a/tests/test_superfluous_elif_break.py
+++ b/tests/test_superfluous_elif_break.py
@@ -1,0 +1,40 @@
+import pytest
+from flake8_plugin_utils import assert_error
+
+from flake8_return.errors import SuperfluousElifBreak
+from flake8_return.visitors import ReturnVisitor
+
+from . import ids
+
+superfluous_elif = (
+    """
+    def foo2(x, y, w, z):
+        for i in x:
+            if i > y:  # [no-else-break]
+                break
+            elif i > w:
+                break
+            else:
+                a = z
+    """,
+    """
+    def foo5(x, y, z):
+        for i in x:
+            if i > y:  # [no-else-break]
+                if y:
+                    a = 4
+                else:
+                    b = 2
+                break
+            elif z:
+                c = 2
+            else:
+                c = 3
+            break
+    """,
+)
+
+
+@pytest.mark.parametrize('src', superfluous_elif, ids=ids(superfluous_elif))
+def test_superfluous_elif_break(src):
+    assert_error(ReturnVisitor, src, SuperfluousElifBreak)

--- a/tests/test_superfluous_elif_break.py
+++ b/tests/test_superfluous_elif_break.py
@@ -1,7 +1,7 @@
 import pytest
 from flake8_plugin_utils import assert_error
 
-from flake8_return.errors import SuperfluousElifBreak
+from flake8_return.errors import SuperfluousElseBreak
 from flake8_return.visitors import ReturnVisitor
 
 from . import ids
@@ -37,4 +37,4 @@ superfluous_elif = (
 
 @pytest.mark.parametrize('src', superfluous_elif, ids=ids(superfluous_elif))
 def test_superfluous_elif_break(src):
-    assert_error(ReturnVisitor, src, SuperfluousElifBreak)
+    assert_error(ReturnVisitor, src, SuperfluousElseBreak)

--- a/tests/test_superfluous_elif_continue.py
+++ b/tests/test_superfluous_elif_continue.py
@@ -1,0 +1,40 @@
+import pytest
+from flake8_plugin_utils import assert_error
+
+from flake8_return.errors import SuperfluousElifContinue
+from flake8_return.visitors import ReturnVisitor
+
+from . import ids
+
+superfluous_elif = (
+    """
+    def foo2(x, y, w, z):
+        for i in x:
+            if i < y:  # [no-else-continue]
+                continue
+            elif i < w:
+                continue
+            else:
+                a = z
+    """,
+    """
+    def foo5(x, y, z):
+        for i in x:
+            if i < y:  # [no-else-continue]
+                if y:
+                    a = 4
+                else:
+                    b = 2
+                continue
+            elif z:
+                c = 2
+            else:
+                c = 3
+            continue
+    """,
+)
+
+
+@pytest.mark.parametrize('src', superfluous_elif, ids=ids(superfluous_elif))
+def test_superfluous_elif_continue(src):
+    assert_error(ReturnVisitor, src, SuperfluousElifContinue)

--- a/tests/test_superfluous_elif_continue.py
+++ b/tests/test_superfluous_elif_continue.py
@@ -1,7 +1,7 @@
 import pytest
 from flake8_plugin_utils import assert_error
 
-from flake8_return.errors import SuperfluousElifContinue
+from flake8_return.errors import SuperfluousElseContinue
 from flake8_return.visitors import ReturnVisitor
 
 from . import ids
@@ -37,4 +37,4 @@ superfluous_elif = (
 
 @pytest.mark.parametrize('src', superfluous_elif, ids=ids(superfluous_elif))
 def test_superfluous_elif_continue(src):
-    assert_error(ReturnVisitor, src, SuperfluousElifContinue)
+    assert_error(ReturnVisitor, src, SuperfluousElseContinue)

--- a/tests/test_superfluous_elif_raise.py
+++ b/tests/test_superfluous_elif_raise.py
@@ -1,0 +1,41 @@
+import pytest
+from flake8_plugin_utils import assert_error
+
+from flake8_return.errors import SuperfluousElifRaise
+from flake8_return.visitors import ReturnVisitor
+
+from . import ids
+
+superfluous_elif = (
+    """
+    def foo2(x, y, w, z):
+        if x:  # [no-else-raise]
+            a = 1
+            raise Exception(y)
+        elif z:
+            b = 2
+            raise Exception(w)
+        else:
+            c = 3
+            raise Exception(z)
+    """,
+    """
+    def foo5(x, y, z):
+        if x: # [no-else-raise]
+            if y:
+                a = 4
+            else:
+                b = 2
+            raise Exception(x)
+        elif z:
+            raise Exception(y)
+        else:
+            c = 3
+        raise Exception(z)
+    """,
+)
+
+
+@pytest.mark.parametrize('src', superfluous_elif, ids=ids(superfluous_elif))
+def test_superfluous_elif_raise(src):
+    assert_error(ReturnVisitor, src, SuperfluousElifRaise)

--- a/tests/test_superfluous_elif_raise.py
+++ b/tests/test_superfluous_elif_raise.py
@@ -1,7 +1,7 @@
 import pytest
 from flake8_plugin_utils import assert_error
 
-from flake8_return.errors import SuperfluousElifRaise
+from flake8_return.errors import SuperfluousElseRaise
 from flake8_return.visitors import ReturnVisitor
 
 from . import ids
@@ -38,4 +38,4 @@ superfluous_elif = (
 
 @pytest.mark.parametrize('src', superfluous_elif, ids=ids(superfluous_elif))
 def test_superfluous_elif_raise(src):
-    assert_error(ReturnVisitor, src, SuperfluousElifRaise)
+    assert_error(ReturnVisitor, src, SuperfluousElseRaise)

--- a/tests/test_superfluous_elif_return.py
+++ b/tests/test_superfluous_elif_return.py
@@ -1,0 +1,41 @@
+import pytest
+from flake8_plugin_utils import assert_error
+
+from flake8_return.errors import SuperfluousElifReturn
+from flake8_return.visitors import ReturnVisitor
+
+from . import ids
+
+superfluous_elif = (
+    """
+    def foo2(x, y, w, z):
+        if x:  # [no-else-return]
+            a = 1
+            return y
+        elif z:
+            b = 2
+            return w
+        else:
+            c = 3
+            return z
+    """,
+    """
+    def foo5(x, y, z):
+        if x:   # [no-else-return]
+            if y:
+                a = 4
+            else:
+                b = 2
+            return
+        elif z:
+            c = 2
+        else:
+            c = 3
+        return
+    """,
+)
+
+
+@pytest.mark.parametrize('src', superfluous_elif, ids=ids(superfluous_elif))
+def test_superfluous_elif_return(src):
+    assert_error(ReturnVisitor, src, SuperfluousElifReturn)

--- a/tests/test_superfluous_elif_return.py
+++ b/tests/test_superfluous_elif_return.py
@@ -33,6 +33,25 @@ superfluous_elif = (
             c = 3
         return
     """,
+    """
+    def foo2(x, y, w, z):
+        if x:
+            a = 1
+        elif z:
+            b = 2
+        else:
+            c = 3
+
+        if x:  # [no-else-return]
+            a = 1
+            return y
+        elif z:
+            b = 2
+            return w
+        else:
+            c = 3
+            return z
+    """
 )
 
 

--- a/tests/test_superfluous_elif_return.py
+++ b/tests/test_superfluous_elif_return.py
@@ -51,7 +51,7 @@ superfluous_elif = (
         else:
             c = 3
             return z
-    """
+    """,
 )
 
 

--- a/tests/test_superfluous_elif_return.py
+++ b/tests/test_superfluous_elif_return.py
@@ -1,7 +1,7 @@
 import pytest
 from flake8_plugin_utils import assert_error
 
-from flake8_return.errors import SuperfluousElifReturn
+from flake8_return.errors import SuperfluousElseReturn
 from flake8_return.visitors import ReturnVisitor
 
 from . import ids
@@ -38,4 +38,4 @@ superfluous_elif = (
 
 @pytest.mark.parametrize('src', superfluous_elif, ids=ids(superfluous_elif))
 def test_superfluous_elif_return(src):
-    assert_error(ReturnVisitor, src, SuperfluousElifReturn)
+    assert_error(ReturnVisitor, src, SuperfluousElseReturn)

--- a/tests/test_superfluous_else_break.py
+++ b/tests/test_superfluous_else_break.py
@@ -1,0 +1,144 @@
+import pytest
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from flake8_return.errors import SuperfluousElseBreak
+from flake8_return.visitors import ReturnVisitor
+
+from . import ids
+
+superfluous_else = (
+    """
+    def foo1(x, y, z):
+        for i in x:
+            if i > y:  # [no-else-break]
+                break
+            else:
+                a = z
+    """,
+    """
+    def foo3(x, y, z):
+        for i in x:
+            if i > y:
+                a = 1
+                if z:  # [no-else-break]
+                    b = 2
+                    break
+                else:
+                    c = 3
+                    break
+            else:
+                d = 4
+                break
+    """,
+    """
+    def foo4(x, y):
+        for i in x:
+            if i > x:  # [no-else-break]
+                if y:
+                    a = 4
+                else:
+                    b = 2
+                break
+            else:
+                c = 3
+            break
+    """,
+    """
+    def foo6(x, y):
+        for i in x:
+            if i > x:
+                if y:  # [no-else-break]
+                    a = 4
+                    break
+                else:
+                    b = 2
+            else:
+                c = 3
+            break
+    """,
+    """
+    def bar4(x):
+        for i in range(10):
+            if x:  # [no-else-break]
+                break
+            else:
+                try:
+                    return
+                except ValueError:
+                    break
+    """,
+)
+
+
+@pytest.mark.parametrize('src', superfluous_else, ids=ids(superfluous_else))
+def test_superfluous_else_break(src):
+    assert_error(ReturnVisitor, src, SuperfluousElseBreak)
+
+
+error_not_exists = (
+    """
+    def bar4(x):
+        for i in range(10):
+            if x:  # [no-else-break]
+                break
+            else:
+                try:
+                    return
+                except ValueError:
+                    break
+    """,
+    """
+    def bar1(x, y, z):
+        for i in x:
+            if i > y:
+                break
+            return z
+    """,
+    """
+    def bar2(w, x, y, z):
+        for i in w:
+            if i > x:
+                break
+            if z < i:
+                a = y
+            else:
+                break
+            return
+    """,
+    """
+    def bar3(x, y, z):
+        for i in x:
+            if i > y:
+                if z:
+                    break
+            else:
+                return z
+            return None
+    """,
+    """
+    def nested1(x, y, z):
+        for i in x:
+            if i > x:
+                for j in y:
+                    if j < z:
+                        break
+            else:
+                a = z
+    """,
+    """
+    def nested2(x, y, z):
+        for i in x:
+            if i > x:
+                for j in y:
+                    if j > z:
+                        break
+                    break
+            else:
+                a = z
+    """,
+)
+
+
+@pytest.mark.parametrize('src', error_not_exists, ids=ids(error_not_exists))
+def test_error_not_exists(src):
+    assert_not_error(ReturnVisitor, src)

--- a/tests/test_superfluous_else_break.py
+++ b/tests/test_superfluous_else_break.py
@@ -77,17 +77,6 @@ def test_superfluous_else_break(src):
 
 error_not_exists = (
     """
-    def bar4(x):
-        for i in range(10):
-            if x:  # [no-else-break]
-                break
-            else:
-                try:
-                    return
-                except ValueError:
-                    break
-    """,
-    """
     def bar1(x, y, z):
         for i in x:
             if i > y:

--- a/tests/test_superfluous_else_continue.py
+++ b/tests/test_superfluous_else_continue.py
@@ -1,0 +1,150 @@
+import pytest
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from flake8_return.errors import SuperfluousElseContinue
+from flake8_return.visitors import ReturnVisitor
+
+from . import ids
+
+superfluous_else = (
+    """
+    def foo1(x, y, z):
+        for i in x:
+            if i < y:  # [no-else-continue]
+                continue
+            else:
+                a = z
+    """,
+    """
+    def foo3(x, y, z):
+        for i in x:
+            if i < y:
+                a = 1
+                if z:  # [no-else-continue]
+                    b = 2
+                    continue
+                else:
+                    c = 3
+                    continue
+            else:
+                d = 4
+                continue
+    """,
+    """
+    def foo4(x, y):
+        for i in x:
+            if i < x:  # [no-else-continue]
+                if y:
+                    a = 4
+                else:
+                    b = 2
+                continue
+            else:
+                c = 3
+            continue
+    """,
+    """
+    def foo6(x, y):
+        for i in x:
+            if i < x:
+                if y:  # [no-else-continue]
+                    a = 4
+                    continue
+                else:
+                    b = 2
+            else:
+                c = 3
+            continue
+    """,
+    """
+    def bar4(x):
+        for i in range(10):
+            if x:  # [no-else-continue]
+                continue
+            else:
+                try:
+                    return
+                except ValueError:
+                    continue
+    """,
+)
+
+
+@pytest.mark.parametrize('src', superfluous_else, ids=ids(superfluous_else))
+def test_superfluous_else_continue(src):
+    assert_error(ReturnVisitor, src, SuperfluousElseContinue)
+
+
+error_not_exists = (
+    """
+    def bar1(x, y, z):
+        for i in x:
+            if i < y:
+                continue
+            return z
+    """,
+    """
+    def bar2(w, x, y, z):
+        for i in w:
+            if i < x:
+                continue
+            if z < i:
+                a = y
+            else:
+                continue
+            return
+    """,
+    """
+    def bar3(x, y, z):
+        for i in x:
+            if i < y:
+                if z:
+                    continue
+            else:
+                return z
+            return None
+    """,
+    """
+    def nested1(x, y, z):
+        for i in x:
+            if i < x:
+                for j in y:
+                    if j < z:
+                        continue
+            else:
+                a = z
+    """,
+    """
+    def nested2(x, y, z):
+        for i in x:
+            if i < x:
+                for j in y:
+                    if j < z:
+                        continue
+                    continue
+            else:
+                a = z
+    """,
+)
+
+
+@pytest.mark.parametrize('src', error_not_exists, ids=ids(error_not_exists))
+def test_error_not_exists(src):
+    assert_not_error(ReturnVisitor, src)
+    """
+    def bar1(x, y, z):
+        for i in x:
+            if i < y:
+                continue
+            return z
+    """,
+    """
+    def bar3(x, y, z):
+        for i in x:
+            if i < y:
+                if z:
+                    continue
+            else:
+                return z
+            return None
+    """,

--- a/tests/test_superfluous_else_raise.py
+++ b/tests/test_superfluous_else_raise.py
@@ -1,0 +1,106 @@
+import pytest
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from flake8_return.errors import SuperfluousElseRaise
+from flake8_return.visitors import ReturnVisitor
+
+from . import ids
+
+superfluous_else = (
+    """
+    def foo1(x, y, z):
+        if x:  # [no-else-raise]
+            a = 1
+            raise Exception(y)
+        else:
+            b = 2
+            raise Exception(z)
+    """,
+    """
+    def foo3(x, y, z):
+        if x:
+            a = 1
+            if y:  # [no-else-raise]
+                b = 2
+                raise Exception(y)
+            else:
+                c = 3
+                raise Exception(x)
+        else:
+            d = 4
+            raise Exception(z)
+    """,
+    """
+    def foo4(x, y):
+        if x: # [no-else-raise]
+            if y:
+                a = 4
+            else:
+                b = 2
+            raise Exception(x)
+        else:
+            c = 3
+        raise Exception(y)
+    """,
+    """
+    def foo6(x, y):
+        if x:
+            if y:   # [no-else-raise]
+                a = 4
+                raise Exception(x)
+            else:
+                b = 2
+        else:
+            c = 3
+        raise Exception(y)
+    """,
+    """
+    def bar4(x):
+        if x:  # [no-else-raise]
+            raise Exception(True)
+        else:
+            try:
+                raise Exception(False)
+            except ValueError:
+                raise Exception(None)
+    """,
+)
+
+
+@pytest.mark.parametrize('src', superfluous_else, ids=ids(superfluous_else))
+def test_superfluous_else_raise(src):
+    assert_error(ReturnVisitor, src, SuperfluousElseRaise)
+
+
+error_not_exists = (
+    """
+    def bar1(x, y, z):
+        if x:
+            raise Exception(y)
+        raise Exception(z)
+    """,
+    """
+    def bar2(w, x, y, z):
+        if x:
+            raise Exception(y)
+        if z:
+            a = 1
+        else:
+            raise Exception(w)
+        raise Exception(None)
+    """,
+    """
+    def bar3(x, y, z):
+        if x:
+            if z:
+                raise Exception(y)
+        else:
+            raise Exception(z)
+        raise Exception(None)
+    """,
+)
+
+
+@pytest.mark.parametrize('src', error_not_exists, ids=ids(error_not_exists))
+def test_error_not_exists(src):
+    assert_not_error(ReturnVisitor, src)

--- a/tests/test_superfluous_else_return.py
+++ b/tests/test_superfluous_else_return.py
@@ -74,30 +74,30 @@ def test_superfluous_else_return(src):
 
 error_not_exists = (
     """
-def bar1(x, y, z):
-    if x:
-        return y
-    return z
-""",
-    """
-def bar2(w, x, y, z):
-    if x:
-        return y
-    if z:
-        a = 1
-    else:
-        return w
-    return None
-""",
-    """
-def bar3(x, y, z):
-    if x:
-        if z:
+    def bar1(x, y, z):
+        if x:
             return y
-    else:
         return z
-    return None
-""",
+    """,
+    """
+    def bar2(w, x, y, z):
+        if x:
+            return y
+        if z:
+            a = 1
+        else:
+            return w
+        return None
+    """,
+    """
+    def bar3(x, y, z):
+        if x:
+            if z:
+                return y
+        else:
+            return z
+        return None
+    """,
 )
 
 

--- a/tests/test_superfluous_else_return.py
+++ b/tests/test_superfluous_else_return.py
@@ -98,6 +98,16 @@ error_not_exists = (
             return z
         return None
     """,
+    """
+    x = 0
+
+    if x == 1:
+        y = "a"
+    elif x == 2:
+        y = "b"
+    else:
+        y = "c"
+    """,
 )
 
 

--- a/tests/test_superfluous_else_return.py
+++ b/tests/test_superfluous_else_return.py
@@ -1,0 +1,106 @@
+import pytest
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from flake8_return.errors import SuperfluousElseReturn
+from flake8_return.visitors import ReturnVisitor
+
+from . import ids
+
+superfluous_else = (
+    """
+    def foo1(x, y, z):
+        if x:  # [no-else-return]
+            a = 1
+            return y
+        else:
+            b = 2
+            return z
+    """,
+    """
+    def foo3(x, y, z):
+        if x:
+            a = 1
+            if y:  # [no-else-return]
+                b = 2
+                return y
+            else:
+                c = 3
+                return x
+        else:
+            d = 4
+            return z
+    """,
+    """
+    def foo4(x, y):
+        if x:   # [no-else-return]
+            if y:
+                a = 4
+            else:
+                b = 2
+            return
+        else:
+            c = 3
+        return
+    """,
+    """
+    def foo6(x, y):
+        if x:
+            if y:   # [no-else-return]
+                a = 4
+                return
+            else:
+                b = 2
+        else:
+            c = 3
+        return
+    """,
+    """
+    def bar4(x):
+        if x:  # [no-else-return]
+            return True
+        else:
+            try:
+                return False
+            except ValueError:
+                return None
+    """,
+)
+
+
+@pytest.mark.parametrize('src', superfluous_else, ids=ids(superfluous_else))
+def test_superfluous_else_return(src):
+    assert_error(ReturnVisitor, src, SuperfluousElseReturn)
+
+
+error_not_exists = (
+    """
+def bar1(x, y, z):
+    if x:
+        return y
+    return z
+""",
+    """
+def bar2(w, x, y, z):
+    if x:
+        return y
+    if z:
+        a = 1
+    else:
+        return w
+    return None
+""",
+    """
+def bar3(x, y, z):
+    if x:
+        if z:
+            return y
+    else:
+        return z
+    return None
+""",
+)
+
+
+@pytest.mark.parametrize('src', error_not_exists, ids=ids(error_not_exists))
+def test_error_not_exists(src):
+    assert_not_error(ReturnVisitor, src)

--- a/tests/test_unnecessary_assign.py
+++ b/tests/test_unnecessary_assign.py
@@ -201,14 +201,15 @@ if sys.version_info >= (3, 8):
 
                 username = username.replace(' ', '_')  # Avoid spaces or %20.
                 try:
-                    username.encode('ascii')  # just test, but not actually use it
+                    username.encode('ascii')  # just test,
+                                              # but not actually use it
                 except UnicodeEncodeError:
                     username = quote(username.encode('utf-8'))
                 else:
                     # % is legal in the default $wgLegalTitleChars
                     # This is so that ops know the real pywikibot will not
-                    # allow a useragent in the username to allow through a hand-coded
-                    # percent-encoded value.
+                    # allow a useragent in the username to allow through a
+                    # hand-coded percent-encoded value.
                     if '%' in username:
                         username = quote(username)
                 return username
@@ -271,14 +272,15 @@ else:
 
                 username = username.replace(' ', '_')  # Avoid spaces or %20.
                 try:
-                    username.encode('ascii')  # just test, but not actually use it
+                    username.encode('ascii')  # just test,
+                                              # but not actually use it
                 except UnicodeEncodeError:
                     username = quote(username.encode('utf-8'))
                 else:
                     # % is legal in the default $wgLegalTitleChars
                     # This is so that ops know the real pywikibot will not
-                    # allow a useragent in the username to allow through a hand-coded
-                    # percent-encoded value.
+                    # allow a useragent in the username to allow through a
+                    # hand-coded percent-encoded value.
                     if '%' in username:
                         return quote(username)
                 finally:

--- a/tests/test_unnecessary_assign.py
+++ b/tests/test_unnecessary_assign.py
@@ -193,97 +193,97 @@ if sys.version_info >= (3, 8):
     error_not_exists.extend(
         [
             """
-    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
-    def user_agent_username(username=None):
+            # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
+            def user_agent_username(username=None):
 
-        if not username:
-            return ''
+                if not username:
+                    return ''
 
-        username = username.replace(' ', '_')  # Avoid spaces or %20.
-        try:
-            username.encode('ascii')  # just test, but not actually use it
-        except UnicodeEncodeError:
-            username = quote(username.encode('utf-8'))
-        else:
-            # % is legal in the default $wgLegalTitleChars
-            # This is so that ops know the real pywikibot will not
-            # allow a useragent in the username to allow through a hand-coded
-            # percent-encoded value.
-            if '%' in username:
-                username = quote(username)
-        return username
-    """,
+                username = username.replace(' ', '_')  # Avoid spaces or %20.
+                try:
+                    username.encode('ascii')  # just test, but not actually use it
+                except UnicodeEncodeError:
+                    username = quote(username.encode('utf-8'))
+                else:
+                    # % is legal in the default $wgLegalTitleChars
+                    # This is so that ops know the real pywikibot will not
+                    # allow a useragent in the username to allow through a hand-coded
+                    # percent-encoded value.
+                    if '%' in username:
+                        username = quote(username)
+                return username
+            """,
             """
-    # https://github.com/afonasev/flake8-return/issues/116#issue-1367575481
-    def no_exception_loop():
-        success = False
-        for _ in range(10):
-            try:
+            # https://github.com/afonasev/flake8-return/issues/116#issue-1367575481
+            def no_exception_loop():
+                success = False
+                for _ in range(10):
+                    try:
+                        success = True
+                    except Exception:
+                        print("exception")
+                return success
+            """,
+            """
+            # https://github.com/afonasev/flake8-return/issues/116#issue-1367575481
+            def no_exception():
+                success = False
+                try:
+                    success = True
+                except Exception:
+                    print("exception")
+                return success
+            """,
+            """
+            # https://github.com/afonasev/flake8-return/issues/116#issue-1367575481
+            def exception():
                 success = True
-            except Exception:
-                print("exception")
-        return success
-    """,
+                try:
+                    print("raising")
+                    raise Exception
+                except Exception:
+                    success = False
+                return success
+            """,
             """
-    # https://github.com/afonasev/flake8-return/issues/116#issue-1367575481
-    def no_exception():
-        success = False
-        try:
-            success = True
-        except Exception:
-            print("exception")
-        return success
-    """,
-            """
-    # https://github.com/afonasev/flake8-return/issues/116#issue-1367575481
-    def exception():
-        success = True
-        try:
-            print("raising")
-            raise Exception
-        except Exception:
-            success = False
-        return success
-    """,
-            """
-    # https://github.com/afonasev/flake8-return/issues/66
-    def close(self):
-        any_failed = False
-        for task in self.tasks:
-            try:
-                task()
-            except BaseException:
-                any_failed = True
-                report(traceback.format_exc())
-        return any_failed
-    """,
+            # https://github.com/afonasev/flake8-return/issues/66
+            def close(self):
+                any_failed = False
+                for task in self.tasks:
+                    try:
+                        task()
+                    except BaseException:
+                        any_failed = True
+                        report(traceback.format_exc())
+                return any_failed
+            """,
         ]
     )
 else:
     error_not_exists.extend(
         [
             """
-    # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
-    def user_agent_username(username=None):
+            # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
+            def user_agent_username(username=None):
 
-        if not username:
-            return ''
+                if not username:
+                    return ''
 
-        username = username.replace(' ', '_')  # Avoid spaces or %20.
-        try:
-            username.encode('ascii')  # just test, but not actually use it
-        except UnicodeEncodeError:
-            username = quote(username.encode('utf-8'))
-        else:
-            # % is legal in the default $wgLegalTitleChars
-            # This is so that ops know the real pywikibot will not
-            # allow a useragent in the username to allow through a hand-coded
-            # percent-encoded value.
-            if '%' in username:
-                return quote(username)
-        finally:
-            return username
-    """,
+                username = username.replace(' ', '_')  # Avoid spaces or %20.
+                try:
+                    username.encode('ascii')  # just test, but not actually use it
+                except UnicodeEncodeError:
+                    username = quote(username.encode('utf-8'))
+                else:
+                    # % is legal in the default $wgLegalTitleChars
+                    # This is so that ops know the real pywikibot will not
+                    # allow a useragent in the username to allow through a hand-coded
+                    # percent-encoded value.
+                    if '%' in username:
+                        return quote(username)
+                finally:
+                    return username
+            """,
         ]
     )
 


### PR DESCRIPTION
This PR ports the listed checks from pylint for reasons described in #14.

Test cases for each check taken from pylint tests: 
- [no-else-return](https://github.com/PyCQA/pylint/blob/c2a3e84f32559c434208ae1eede65ad5ca767b8d/tests/functional/n/no/no_else_return.py)
- [no-else-break](https://github.com/PyCQA/pylint/blob/c2a3e84f32559c434208ae1eede65ad5ca767b8d/tests/functional/n/no/no_else_break.py)
- [no-else-continue](https://github.com/PyCQA/pylint/blob/c2a3e84f32559c434208ae1eede65ad5ca767b8d/tests/functional/n/no/no_else_continue.py)
- [no-else-raise](https://github.com/PyCQA/pylint/blob/c2a3e84f32559c434208ae1eede65ad5ca767b8d/tests/functional/n/no/no_else_raise.py)